### PR TITLE
SXM-1: Add Fetch Logger

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Controls from './components/Controls';
 import Visualizer from './components/Visualizer';
 import Login from './components/Login';
 import { handleLogin } from './api/login';
+import { loggedFetch } from './lib/loggedFetch';
 import './App.css';
 
 type StreamItem = {
@@ -55,7 +56,7 @@ const App: React.FC = () => {
 			let lastErr: unknown;
 			for (let attempt = 0; attempt < 3; attempt++) {
 				try {
-					const res = await fetch('/streams', { cache: 'no-store' });
+					const res = await loggedFetch('/streams', { cache: 'no-store' });
 					const ctype = res.headers.get('content-type') || '';
 					if (!res.ok) throw new Error(`GET /streams ${res.status}`);
 					if (!ctype.includes('application/json')) {

--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -1,3 +1,5 @@
+import { loggedFetch } from "../lib/loggedFetch";
+
 export async function handleLogin({
 	email,
 	password,
@@ -6,7 +8,7 @@ export async function handleLogin({
 	password: string;
 }): Promise<{ success: boolean; error?: string }> {
 	try {
-		const response = await fetch('/login', {
+		const response = await loggedFetch('/login', {
 			method: 'POST',
 			headers: { 'content-type': 'application/json' },
 			body: JSON.stringify({ email, password }),

--- a/src/components/MockDemo.tsx
+++ b/src/components/MockDemo.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
+import { loggedFetch } from '../lib/loggedFetch';
 
 export function MockDemo() {
 	const [data, setData] = useState(null);
 
 	useEffect(() => {
-		fetch('/hello-world')
+		loggedFetch('/hello-world')
 			.then((res) => res.json())
 			.then((res) => {
 				console.log(res.data);

--- a/src/lib/loggedFetch.ts
+++ b/src/lib/loggedFetch.ts
@@ -11,7 +11,7 @@ export async function loggedFetch(
 	options?: LoggedFetchOptions,
 ) {
 	const logger = options?.logger ?? getRequestLogger();
-	const method = init?.method ?? 'GET'
+	const method = init?.method === 'GET' ? init.method : 'GET'
 
 	logger.logRequest({ method, url, body: init?.body ?? null });
 

--- a/src/lib/loggedFetch.ts
+++ b/src/lib/loggedFetch.ts
@@ -1,0 +1,32 @@
+import type { RequestLogger } from './requestLogger';
+import { getRequestLogger } from './requestLogger';
+
+type LoggedFetchOptions = {
+	logger?: RequestLogger;
+};
+
+export async function loggedFetch(
+	url: string,
+	init?: RequestInit,
+	options?: LoggedFetchOptions,
+) {
+	const logger = options?.logger ?? getRequestLogger();
+	const method = init?.method ?? 'GET'
+
+	logger.logRequest({ method, url, body: init?.body ?? null });
+
+	try {
+		const response = await window.fetch(url, init);
+		logger.logResponse({
+			method,
+			url,
+			body: init?.body ?? null,
+			status: response.status,
+			ok: response.ok,
+		});
+		return response;
+	} catch (error) {
+		logger.logError({ method, url, body: init?.body ?? null, error });
+		throw error;
+	}
+}

--- a/src/lib/requestLogger.ts
+++ b/src/lib/requestLogger.ts
@@ -1,0 +1,37 @@
+export type RequestLog = {
+	method: string;
+	url: string;
+	body?: BodyInit | null;
+};
+
+export type ResponseLog = RequestLog & {
+	status: number;
+	ok: boolean;
+};
+
+export type ErrorLog = RequestLog & {
+	error: unknown;
+};
+
+export type RequestLogger = {
+	logRequest: (entry: RequestLog) => void;
+	logResponse: (entry: ResponseLog) => void;
+	logError: (entry: ErrorLog) => void;
+};
+
+const defaultLogger: RequestLogger = {
+	logRequest: ({ method, url }) => {
+		console.info(`[fetch] ${method.toUpperCase()} ${url}`);
+	},
+	logResponse: ({ method, url, status, ok }) => {
+		const state = ok ? 'ok' : 'error';
+		console.info(`[fetch] ${method.toUpperCase()} ${url} -> ${status} (${state})`);
+	},
+	logError: ({ method, url, error }) => {
+		console.error(`[fetch] ${method.toUpperCase()} ${url} failed`, error);
+	},
+};
+
+export function getRequestLogger(): RequestLogger {
+	return defaultLogger;
+}


### PR DESCRIPTION
## Summary

For the ticket SXM-1 we want to add a logger that wraps fetch and logs some extra context about the request and response.

## Testing Steps

1. On app load there should be a GET request logged to the /streams endpoint.
2. On sign in a POST request to the /login endpoint should be logged.